### PR TITLE
Add Permissions for Cloud Run Service Cost Recommender

### DIFF
--- a/gcp/Org-role.tf
+++ b/gcp/Org-role.tf
@@ -52,6 +52,8 @@ resource "google_organization_iam_custom_role" "ternary_service_agent" {
     "recommender.networkAnalyzerIpAddressInsights.list", # Unused Static IP Address Recommendations
     "recommender.resourcemanagerProjectUtilizationRecommendations.get", # [Future] Unattended Project Recommendations
     "recommender.resourcemanagerProjectUtilizationRecommendations.list", # [Future] Unattended Project Recommendations
+    "recommender.runServiceCostRecommendations.get", # Cloud Run Cost Recommendations
+    "recommender.runServiceCostRecommendations.list", # Cloud Run Cost Recommendations
     "recommender.spendBasedCommitmentInsights.get", # Spend Based Commitment Recommendations
     "recommender.spendBasedCommitmentInsights.list", # Spend Based Commitment Recommendations
     "recommender.spendBasedCommitmentRecommendations.get", # Spend Based Commitment Recommendations

--- a/gcp/Org-role.yaml
+++ b/gcp/Org-role.yaml
@@ -48,12 +48,14 @@ includedPermissions:
   - recommender.networkAnalyzerIpAddressInsights.list # Unused Static IP Address Recommendations
   - recommender.resourcemanagerProjectUtilizationRecommendations.get # [Future] Unattended Project Recommendations
   - recommender.resourcemanagerProjectUtilizationRecommendations.list # [Future] Unattended Project Recommendations
+  - recommender.runServiceCostRecommendations.get # Cloud Run Cost Recommendations
+  - recommender.runServiceCostRecommendations.list # Cloud Run Cost Recommendations
   - recommender.spendBasedCommitmentInsights.get # Spend Based Commitment Recommendations
   - recommender.spendBasedCommitmentInsights.list # Spend Based Commitment Recommendations
-  - recommender.spendBasedCommitmentRecommendations.get # [Future] Spend Based Commitment Recommendations
-  - recommender.spendBasedCommitmentRecommendations.list # [Future] Spend Based Commitment Recommendations
-  - recommender.usageCommitmentRecommendations.get # [Future] Usage Based Commitment Recommendations
-  - recommender.usageCommitmentRecommendations.list # [Future] Usage Based Commitment Recommendations
+  - recommender.spendBasedCommitmentRecommendations.get # Spend Based Commitment Recommendations
+  - recommender.spendBasedCommitmentRecommendations.list # Spend Based Commitment Recommendations
+  - recommender.usageCommitmentRecommendations.get # Usage Based Commitment Recommendations
+  - recommender.usageCommitmentRecommendations.list # Usage Based Commitment Recommendations
   - resourcemanager.folders.get # Allows Ternary to traverse GCP Organizations and find projects
   - resourcemanager.folders.list # Allows Ternary to traverse GCP Organizations and find projects
   - resourcemanager.organizations.get # Allows Ternary to traverse GCP Organizations and find projects

--- a/gcp/Project-role.tf
+++ b/gcp/Project-role.tf
@@ -52,12 +52,14 @@ resource "google_organization_iam_custom_role" "ternary_service_agent" {
     "recommender.networkAnalyzerIpAddressInsights.list", # Unused Static IP Address Recommendations
     "recommender.resourcemanagerProjectUtilizationRecommendations.get", # [Future] Unattended Project Recommendations
     "recommender.resourcemanagerProjectUtilizationRecommendations.list", # [Future] Unattended Project Recommendations
+    "recommender.runServiceCostRecommendations.get", # Cloud Run Cost Recommendations
+    "recommender.runServiceCostRecommendations.list", # Cloud Run Cost Recommendations
     "recommender.spendBasedCommitmentInsights.get", # Spend Based Commitment Recommendations
     "recommender.spendBasedCommitmentInsights.list", # Spend Based Commitment Recommendations
-    "recommender.spendBasedCommitmentRecommendations.get", # [Future] Spend Based Commitment Recommendations
-    "recommender.spendBasedCommitmentRecommendations.list", # [Future] Spend Based Commitment Recommendations
-    "recommender.usageCommitmentRecommendations.get", # [Future] Usage Based Commitment Recommendations
-    "recommender.usageCommitmentRecommendations.list", # [Future] Usage Based Commitment Recommendations
+    "recommender.spendBasedCommitmentRecommendations.get", # Spend Based Commitment Recommendations
+    "recommender.spendBasedCommitmentRecommendations.list", # Spend Based Commitment Recommendations
+    "recommender.usageCommitmentRecommendations.get", # Usage Based Commitment Recommendations
+    "recommender.usageCommitmentRecommendations.list", # Usage Based Commitment Recommendations
     "resourcemanager.projects.get", # List Projects, used in multiple features
   ]
 }

--- a/gcp/Project-role.yaml
+++ b/gcp/Project-role.yaml
@@ -48,12 +48,14 @@ includedPermissions:
   - recommender.networkAnalyzerIpAddressInsights.list # Unused Static IP Address Recommendations
   - recommender.resourcemanagerProjectUtilizationRecommendations.get # [Future] Unattended Project Recommendations
   - recommender.resourcemanagerProjectUtilizationRecommendations.list # [Future] Unattended Project Recommendations
+  - recommender.runServiceCostRecommendations.get # Cloud Run Cost Recommendations
+  - recommender.runServiceCostRecommendations.list # Cloud Run Cost Recommendations
   - recommender.spendBasedCommitmentInsights.get # Spend Based Commitment Recommendations
   - recommender.spendBasedCommitmentInsights.list # Spend Based Commitment Recommendations
-  - recommender.spendBasedCommitmentRecommendations.get # [Future] Spend Based Commitment Recommendations
-  - recommender.spendBasedCommitmentRecommendations.list # [Future] Spend Based Commitment Recommendations
-  - recommender.usageCommitmentRecommendations.get # [Future] Usage Based Commitment Recommendations
-  - recommender.usageCommitmentRecommendations.list # [Future] Usage Based Commitment Recommendations
+  - recommender.spendBasedCommitmentRecommendations.get # Spend Based Commitment Recommendations
+  - recommender.spendBasedCommitmentRecommendations.list # Spend Based Commitment Recommendations
+  - recommender.usageCommitmentRecommendations.get # Usage Based Commitment Recommendations
+  - recommender.usageCommitmentRecommendations.list # Usage Based Commitment Recommendations
   - resourcemanager.projects.get # List Projects, used in multiple features
 name: organizations/{CHANGE-ME}/roles/TernaryCMPServiceAgent
 stage: GA


### PR DESCRIPTION
This change adds the permissions necessary to get and list the [Cloud Run Service Cost Recommendations](https://cloud.google.com/run/docs/recommender). Additionally, remove `Future` from currently in-use permissions. 