### PR TITLE
Add Permissions For BigQuery Cost Recommender

### DIFF
--- a/gcp/Org-role.tf
+++ b/gcp/Org-role.tf
@@ -14,6 +14,8 @@ resource "google_organization_iam_custom_role" "ternary_service_agent" {
     "bigquery.reservationAssignments.search", # BigQuery Visibility Feature
     "bigquery.reservations.get", # BigQuery Visibility Feature
     "bigquery.reservations.list", # BigQuery Visibility Feature
+    "bigquery.tables.get", # BigQuery Optimizations Feature
+    "bigquery.tables.list", # BigQuery Optimizations Feature
     "billing.resourceCosts.get", # View project-scoped requirements reflecting custom contract pricing
     "cloudasset.assets.exportResource", # Find projects with a specific asset type (ex. CUD, Compute Instance, etc.)
     "compute.commitments.list", # GCE CUD Planning feature, CUD expiration alerts

--- a/gcp/Org-role.yaml
+++ b/gcp/Org-role.yaml
@@ -10,6 +10,8 @@ includedPermissions:
   - bigquery.reservationAssignments.search # BigQuery Visibility Feature
   - bigquery.reservations.get # BigQuery Visibility Feature
   - bigquery.reservations.list # BigQuery Visibility Feature
+  - bigquery.tables.get # BigQuery Optimizations Feature
+  - bigquery.tables.list # BigQuery Optimizations Feature
   - billing.resourceCosts.get # View project-scoped requirements reflecting custom contract pricing
   - cloudasset.assets.exportResource # Find projects with a specific asset type (ex. CUD, Compute Instance, etc.)
   - compute.commitments.list # GCE CUD Planning feature, CUD expiration alerts


### PR DESCRIPTION
This change adds the permissions necessary to get and list BigQuery Storage data. 