### PR TITLE
Add Permissions for BigQuery Table Recommender

### DIFF
--- a/gcp/Org-role.tf
+++ b/gcp/Org-role.tf
@@ -24,6 +24,8 @@ resource "google_organization_iam_custom_role" "ternary_service_agent" {
     "recommender.bigqueryCapacityCommitmentsInsights.list", # [Future] BigQuery Slot Reservation Recommendations
     "recommender.bigqueryCapacityCommitmentsRecommendations.get", # [Future] BigQuery Slot Reservation Recommendations
     "recommender.bigqueryCapacityCommitmentsRecommendations.list", # [Future] BigQuery Slot Reservation Recommendations
+    "recommender.bigqueryPartitionClusterRecommendations.get", # BigQuery Table Recommendations
+    "recommender.bigqueryPartitionClusterRecommendations.list", # BigQuery Table Recommendations
     "recommender.cloudsqlIdleInstanceRecommendations.get", # Cloud SQL Idle Resource Recommendations
     "recommender.cloudsqlIdleInstanceRecommendations.list", # Cloud SQL Idle Resource Recommendations
     "recommender.cloudsqlInstanceOutOfDiskRecommendations.get",  # [Future] Cloud SQL Disk Recommendations

--- a/gcp/Org-role.yaml
+++ b/gcp/Org-role.yaml
@@ -20,6 +20,8 @@ includedPermissions:
   - recommender.bigqueryCapacityCommitmentsInsights.list # [Future] BigQuery Slot Reservation Recommendations
   - recommender.bigqueryCapacityCommitmentsRecommendations.get # [Future] BigQuery Slot Reservation Recommendations
   - recommender.bigqueryCapacityCommitmentsRecommendations.list # [Future] BigQuery Slot Reservation Recommendations
+  - recommender.bigqueryPartitionClusterRecommendations.get # BigQuery Table Recommendations
+  - recommender.bigqueryPartitionClusterRecommendations.list # BigQuery Table Recommendations
   - recommender.cloudsqlIdleInstanceRecommendations.get # Cloud SQL Idle Resource Recommendations
   - recommender.cloudsqlIdleInstanceRecommendations.list # Cloud SQL Idle Resource Recommendations
   - recommender.cloudsqlInstanceOutOfDiskRecommendations.get # [Future] Cloud SQL Disk Recommendations


### PR DESCRIPTION
This change adds the permissions necessary to get and list the recommendations produced by Google Cloud BigQuery Partition and Cluster Recommender. 