### PR TITLE
Remove Deprecation Statement for aws/linked-accounts

### DIFF
--- a/aws/README.md
+++ b/aws/README.md
@@ -9,7 +9,9 @@ Ternary. Generally speaking, Ternary will:
 
 There are 3 different modules in this directory; all of them are provided in
 both CloudFormation and Terraform format. Each role allows Ternary to access
-different parts of your AWS environment.
+different parts of your AWS environment. For an AWS Organization with multiple
+member accounts, a fully featured AWS integration will typicaly use all three
+modules.
 
 ## payer-account
 
@@ -38,11 +40,9 @@ metrics.
 
 ## linked-account
 
-**DEPRECATED: Please use `centralized-monitoring` instead.**
-
 The linked-account directory houses the code necessary to create the
 `TernaryCMPLinkedAccountAgent` role. This role is meant for any Linked Account
 with resources that you would like Ternary to be made aware of (Reserved
-Instances, Savings Plans, etc.)
+Instances, Savings Plans, etc.), and should be created in each Linked Account.
 
 [aws-centralized-monitoring]: https://github.com/TernaryInc/aws-centralized-monitoring

--- a/aws/linked-account/README.md
+++ b/aws/linked-account/README.md
@@ -1,9 +1,5 @@
 # linked-account
 
-**WARNING: This deployment method is being sunset and is not officially
-supported for new deploys. Unless you've been sent here by our Success
-Team, we strongly recommend using [aws-centralized-monitoring] instead.**
-
 This is simultaneously a Terraform module as well as a repository housing an
 equivalent CloudFormation template, `ternary-linked-account-cfn.json`.
 Uploading a CloudFormation template to the AWS console is an exercise left to


### PR DESCRIPTION
Clarifies that Linked Accounts onboarding is still useful and aws-centralized-monitoring is not a full replacement for it.